### PR TITLE
Expanding compiler arguemnts

### DIFF
--- a/bootstrap/ts/arguments.ts
+++ b/bootstrap/ts/arguments.ts
@@ -27,7 +27,7 @@ export enum Flags {
 
 /** The compiler options, after parsing inputs from the command line  */
 export const CompilerOptions: Record<Options, string> = {
-	[Options.OutputFile]: "./out",
+	[Options.OutputFile]: null,
 	[Options.OutputDirectory]: "./",
 }
 

--- a/bootstrap/ts/arguments.ts
+++ b/bootstrap/ts/arguments.ts
@@ -22,7 +22,8 @@ export enum Flags {
 	 * a file with all macros and preprocessor
 	 * statements */
 	EmitPreprocessed = "p",
-	TypeCheck = "t"
+	TypeCheck = "t",
+	RunAfterCompile = "r"
 }
 
 /** The compiler options, after parsing inputs from the command line  */
@@ -36,6 +37,7 @@ export const CompilerFlags: Record<Flags, boolean> = {
 	[Flags.Debug]: false,
 	[Flags.EmitPreprocessed]: false,
 	[Flags.TypeCheck]: false,
+	[Flags.RunAfterCompile]: false,
 }
 
 // Iterate over the command line arguments, and parse the options and flags

--- a/bootstrap/ts/parser.ts
+++ b/bootstrap/ts/parser.ts
@@ -454,15 +454,18 @@ const compilerProcessor: TokenProcessor<Compiler> = {
 export class Compiler {
 	static fromSource(sourcePath: string): Compiler {
 		const c = new Compiler();
-		// Only strip toast extensions
-		// const toastExtension = ToastExtensions.find((ext) => sourcePath.endsWith(ext))
-		// const sourceBasename = toastExtension? sourcePath.substring(0,-toastExtension.length):sourcePath
 
-		const extension = path.extname(sourcePath).substring(1)
-		const toastExtension = ToastExtensions.indexOf(extension)
-		const sourceBasename = toastExtension != -1 ?
-			path.join(path.dirname(sourcePath), path.basename(sourcePath, `.${ToastExtensions[toastExtension]}`)) :
-			sourcePath
+		let sourceBasename: string
+		if (CompilerOptions[Options.OutputFile] == null) {
+			const extension = path.extname(sourcePath).substring(1)
+
+			const toastExtension = ToastExtensions.indexOf(extension)
+			sourceBasename = toastExtension != -1 ?
+				path.join(path.dirname(sourcePath), path.basename(sourcePath, `.${ToastExtensions[toastExtension]}`)) :
+				sourcePath
+		} else {
+			sourceBasename = CompilerOptions[Options.OutputFile];
+		}
 
 		c.source = new LexerSourceFile(sourcePath)
 		c.outputBasename = path.resolve(CompilerOptions[Options.OutputDirectory], sourceBasename)

--- a/bootstrap/ts/toast.ts
+++ b/bootstrap/ts/toast.ts
@@ -31,15 +31,17 @@ compiler.generateAssembly()
 compiler.write("\ttoastExit 0\n")
 compiler.save()
 compiler.compile(CompilerFlags[Flags.EmitPreprocessed])
-try {
-	compiler.run()
-} catch (e) {
-	const error = e as any
-	const pref = '\t> '
-	errorLogger.flushLog(`------------Run Failed----------------`)
-	errorLogger.flushLog(`${pref}File: ${compiler.source.name} `)
-	errorLogger.flushLog(`${pref}Exit Code: ${error.status} `)
-	errorLogger.flushLog(`${pref}Exit Signal: ${error.signal} `)
-	errorLogger.flushLog(`${pref}Exit output: ${error.stderr?.toString() || "N/A"} `)
-	process.exit(error.status)
+if (CompilerFlags[Flags.RunAfterCompile]) {
+	try {
+		compiler.run()
+	} catch (e) {
+		const error = e as any
+		const pref = '\t> '
+		errorLogger.flushLog(`------------Run Failed----------------`)
+		errorLogger.flushLog(`${pref}File: ${compiler.source.name} `)
+		errorLogger.flushLog(`${pref}Exit Code: ${error.status} `)
+		errorLogger.flushLog(`${pref}Exit Signal: ${error.signal} `)
+		errorLogger.flushLog(`${pref}Exit output: ${error.stderr?.toString() || "N/A"} `)
+		process.exit(error.status)
+	}
 }

--- a/makefile
+++ b/makefile
@@ -19,9 +19,9 @@ TOASTFLAGS = -od bin
 	echo "::endgroup::"
 
 %$(TEST_RUN_SUFFIX): %$(TEST_SUFFIX)
-	# echo "::group::Run $^"
-	# ../bin/$^
-	# echo "::endgroup::"
+	echo "::group::Run $^"
+	./bin/$^
+	echo "::endgroup::"
 
 mkdir_bin: 
 	mkdir -p bin/$(TEST_DIR)


### PR DESCRIPTION
Implemented two compiler arguments:
### Output file
 - Syntax: `-o [file]`
 - Defaut: `./[input file basename]`
 - TypeScript value: `CompilerOptions[OutputFile]`
 - Select the name of the binary the compiler should output. This is appended to the 'OuputDirectory' argument.
 - This argument was already accepted by the argument parser, but unused in compilation until commit 29c9091bc2db41c4372a8981b7da3c33fc4f8572

### Run after compilation
 - Syntax: `-r`
 - Defaut: `false`
 - TypeScript value: `CompilerFlag[RunAfterCompile]`
 - Execute the compiled binary after compilation
 - This was previously the default behavior of the compiler, but limited its flexibility
